### PR TITLE
docs: add troubleshooting link

### DIFF
--- a/official/audrey-ii/README.md
+++ b/official/audrey-ii/README.md
@@ -71,6 +71,10 @@ Or if you don't want to use VSCode, you can run standard gnu `make` in the root 
 `lib/DaisySp` and finally in the repository root. Then you can use `make program` or
 `make program-dfu` to flash the built binary.
 
+## Troubleshooting
+
+For general troubleshooting see [troubleshooting](https://tsemah.notion.site/Troubleshooting-16f6331933b88028a5e5cf0d36c28a8d?pvs=4)
+
 ## License
 
 This project is licensed under the MIT License. See `LICENSE` for details.


### PR DESCRIPTION
I did not find this link when working on the Audrey II and had some trouble after assembling. Thought this was a useful addition.